### PR TITLE
Fix Warning

### DIFF
--- a/streets_matrix_screen/init.lua
+++ b/streets_matrix_screen/init.lua
@@ -196,7 +196,7 @@ minetest.register_entity("streets:matrix_screen_lights", {
 	visual = "cube",
 	visual_size = { x = 0.99, y = 0.99 },
 	on_activate = function(self, staticdata)
-		local pos = self.object:getpos()
+		local pos = self.object:get_pos()
 		if not vector.equals(pos, vector.round(pos)) then
 			self.object:remove()
 			return


### PR DESCRIPTION
This PR fixes this warning:
```
2021-04-24 07:27:08: WARNING[Server]: Call to deprecated function 'getpos', please use 'get_pos' at ...vp/.minetest/mods/streets/streets_matrix_screen/init.lua:199
```